### PR TITLE
fix(layout): fix some ui bug in mobile layout

### DIFF
--- a/components/media/Info.vue
+++ b/components/media/Info.vue
@@ -15,7 +15,6 @@ const directors = $computed(() => item.credits?.crew.filter(person => person.job
 <template>
   <div p4 grid="~ cols-[max-content_1fr]" gap-8 items-center ma max-w-300>
     <NuxtImg
-
       width="400"
       height="600"
       format="webp"
@@ -24,12 +23,11 @@ const directors = $computed(() => item.credits?.crew.filter(person => person.job
       block border="4 gray4/10" w-79 lt-md:hidden
       transition duration-400 object-cover aspect="10/16"
     />
-    <div flex="~ col" p4 gap6>
+    <div lt-md:w="[calc(100vw-2rem)]" flex="~ col" md:p4 gap6>
       <div v-if="item.overview">
         <h2 text-3xl mb4>
           Storyline
         </h2>
-
         <div op80 v-text="item.overview" />
       </div>
 

--- a/components/media/Photos.vue
+++ b/components/media/Photos.vue
@@ -9,7 +9,7 @@ const show = useImageModal()
 </script>
 
 <template>
-  <div flex="~ col" px16 py8 gap6>
+  <div flex="~ col" px4 md:px16 py8 gap6>
     <div flex gap-2 items-baseline>
       <div text-2xl>
         Backdrops

--- a/components/media/Videos.vue
+++ b/components/media/Videos.vue
@@ -7,7 +7,7 @@ defineProps<{
 </script>
 
 <template>
-  <div flex="~ col" px16 py4 gap6>
+  <div flex="~ col" px4 md:px14 py4 gap6>
     <div op50>
       {{ item.videos?.results.length || 0 }} Videos
     </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div h-full w-full font-sans grid="~ lt-lg:rows-[1fr_max-content] lg:cols-[max-content_1fr]" of-hidden>
-    <div of-auto relative data-scroll>
+    <div of-x-hidden of-y-auto relative data-scroll>
       <slot />
     </div>
     <NavBar lg:order-first />


### PR DESCRIPTION
On movie details page, there are some ui bugs in mobile layout with those three tabs.

<img width="526" alt="image" src="https://user-images.githubusercontent.com/42139754/197711913-1ddc06a4-c6fc-4934-b32b-28e2da39205b.png">
<img width="580" alt="image" src="https://user-images.githubusercontent.com/42139754/197712233-c5015be1-c797-4576-9c8f-6971dbb65ec9.png">
<img width="555" alt="image" src="https://user-images.githubusercontent.com/42139754/197712277-e39339b6-6ba0-4ac8-83a1-301eb1dc50fd.png">


