### PR TITLE
chore: update deprecated field

### DIFF
--- a/proxy/routes/ipx/[...path].ts
+++ b/proxy/routes/ipx/[...path].ts
@@ -16,6 +16,6 @@ const ipxMiddleware = createIPXMiddleware(ipx)
 const ipxHandler = fromNodeMiddleware(ipxMiddleware)
 
 export default eventHandler((event) => {
-  event.req.url = `/${event.context.params!.path}`
+  event.node.req.url = `/${event.context.params!.path}`
   return ipxHandler(event)
 })

--- a/proxy/routes/tmdb/[...path].ts
+++ b/proxy/routes/tmdb/[...path].ts
@@ -4,12 +4,12 @@ import { getQuery } from 'ufo'
 const TMDB_API_URL = 'https://api.themoviedb.org/3'
 
 export default defineEventHandler(async (event) => {
-  const query = getQuery(event.req.url!)
+  const query = getQuery(event.node.req.url!)
   // eslint-disable-next-line no-console
   console.log(
     'Fetching TMDB API',
     {
-      url: event.req.url,
+      url: event.node.req.url,
       query,
       params: event.context.params,
     },
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
   }
   catch (e: any) {
     const status = e?.response?.status || 500
-    event.res.statusCode = status
+    event.node.res.statusCode = status
     return e.message?.replace(config.tmdb.apiKey, '***')
   }
 })


### PR DESCRIPTION
use `event.node` instead deprecated fields
```ts
declare class H3Event implements Pick<FetchEvent, "respondWith"> {
    "__is_event__": boolean;
    node: NodeEventContext;
    context: H3EventContext;
    constructor(req: IncomingMessage, res: ServerResponse);
    get path(): string | undefined;
    /** @deprecated Please use `event.node.req` instead. **/
    get req(): IncomingMessage;
    /** @deprecated Please use `event.node.res` instead. **/
    get res(): ServerResponse<IncomingMessage>;
    respondWith(r: H3Response | PromiseLike<H3Response>): void;
}
```