### PR TITLE
fix: scrolling issue

### DIFF
--- a/plugins/scroll.client.ts
+++ b/plugins/scroll.client.ts
@@ -2,7 +2,7 @@
 export default defineNuxtPlugin(() => {
   const nuxtApp = useNuxtApp()
 
-  nuxtApp.hooks.hook('page:transition:finish', async () => {
+  nuxtApp.$router.afterEach(async () => {
     document.querySelector('[data-scroll]')?.scrollTo({ top: 9 })
   })
 })


### PR DESCRIPTION
Scrolling doesn't work after the transition. I updated the `scroll.client.ts` plugin according to Vue docs, and now it is working.