### PR TITLE
fix: remeber scroll position when go to previous page, resolve #16

### DIFF
--- a/plugins/scroll.client.ts
+++ b/plugins/scroll.client.ts
@@ -2,7 +2,39 @@
 export default defineNuxtPlugin(() => {
   const nuxtApp = useNuxtApp()
 
-  nuxtApp.$router.afterEach(async () => {
-    document.querySelector('[data-scroll]')?.scrollTo({ top: 9 })
+
+  // We need to check if the user is going back or not
+  let isBack = false;
+  window.onpopstate = function () {
+    isBack = true;
+  };
+
+  nuxtApp.$router.afterEach(async (to, from) => {
+    if (from.path === to.path) return;
+
+    const currentHistory = {
+      path: from.path,
+      scrollPosition: document.querySelector('[data-scroll]')?.scrollTop
+    }
+
+    const scrollHistory = JSON.parse(localStorage.getItem('scrollHistory') || '[]');
+
+    if (scrollHistory[scrollHistory.length - 1]?.path === to.path && isBack) {
+      // Here we check if the scroll is not biger than the scrollHeight, if it is, scroll to the bottom
+      if (scrollHistory[scrollHistory.length - 1]?.scrollPosition > document.querySelector('[data-scroll]')?.scrollHeight) {
+        document.querySelector('[data-scroll]')?.scrollTo({ top: document.querySelector('[data-scroll]')?.scrollHeight });
+      } else {
+        document.querySelector('[data-scroll]')?.scrollTo({ top: scrollHistory[scrollHistory.length - 1]?.scrollPosition })
+      }
+
+      scrollHistory.pop();
+    }
+    else {
+      scrollHistory.push(currentHistory);
+      document.querySelector('[data-scroll]')?.scrollTo({ top: 9 });
+      isBack = false;
+    }
+
+    localStorage.setItem('scrollHistory', JSON.stringify(scrollHistory));
   })
 })


### PR DESCRIPTION
I used `localstorage` to store previous pages with their scroll position. When the user presses the back button they will be at the same location where they left off. I worked on this solution today and it works now. Please check it once more 