### PR TITLE
fix: view-transitions don’t need layout containment

### DIFF
--- a/components/media/Card.vue
+++ b/components/media/Card.vue
@@ -24,7 +24,7 @@ defineProps<{
         format="webp"
         :src="`/tmdb${item.poster_path}`"
         :alt="item.title || item.name"
-        w-full h-full object-cover contain-layout
+        w-full h-full object-cover
         :style="{ 'view-transition-name': `item-${item.id}` }"
       />
       <div v-else h-full op10 flex>

--- a/components/media/Info.vue
+++ b/components/media/Info.vue
@@ -23,7 +23,7 @@ const directors = computed(() => props.item.credits?.crew.filter(person => perso
       :src="`/tmdb${props.item.poster_path}`"
       :alt="props.item.title || props.item.name"
       block border="4 gray4/10" w-79 lt-md:hidden
-      transition duration-400 object-cover contain-layout aspect="10/16"
+      transition duration-400 object-cover aspect="10/16"
       :style="{ 'view-transition-name': `item-${props.item.id}` }"
     />
     <div lt-md:w="[calc(100vw-2rem)]" flex="~ col" md:p4 gap6>

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ['border-base', 'border-gray-400/20'],
   ],
   rules: [
-    [/^view-transition-([\w-]+)$/, ([, name]) => ({ 'view-transition-name': name, 'contain': 'layout' })],
+    [/^view-transition-([\w-]+)$/, ([, name]) => ({ 'view-transition-name': name })],
   ],
   theme: {
     colors: {


### PR DESCRIPTION
_(Hi, Chrome DevRel here 👋)_

An older version of view-transitions required layout containment, but this is no longer the case. This requirement can safely be removed.