### PR TITLE
fix: imdb url

### DIFF
--- a/components/ExternalLinks.vue
+++ b/components/ExternalLinks.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
 import type { ExternalIds } from '~/types'
 
-defineProps<{
+const props = defineProps<{
   links: ExternalIds
 }>()
+
+const imdbType = computed(() => {
+  if (props.links.imdb_id?.startsWith('nm'))
+    return 'name'
+
+  return 'title'
+})
 </script>
 
 <template>
@@ -40,7 +47,7 @@ defineProps<{
     </a>
     <a
       v-if="links.imdb_id"
-      :href="`https://www.imdb.com/movie/${links.imdb_id}`"
+      :href="`https://www.imdb.com/${imdbType}/${links.imdb_id}`"
       target="_blank"
       aria-label="Link to IMDb account"
       rel="noopener"


### PR DESCRIPTION
Current IMDb url is `imdb.com/movie/:id` for all IMDb links, when it should be `imdb.com/title/:id` for `media` and `imdb.com/name/:id` for `person`.

I noticed that they use prefix `tt` for `media` and `nm` for `person` so I use that to differentiate between the two for the current solution.

Maybe a better approach would be to add a new `imdbType` prop to `ExternalLinks` component, but I'll let you guys decide.