### PR TITLE
Fix centered navigation buttons

### DIFF
--- a/components/photo/Modal.vue
+++ b/components/photo/Modal.vue
@@ -47,12 +47,12 @@ useEventListener('keydown', (e) => {
       aria-hidden="true"
       max-w-full max-h-full object-contain
     />
-    <div absolute left-0 top="1/2">
+    <div absolute left-0 top="calc(1/2-58px)">
       <button py10 px4 bg-black:30 op10 hover:op100 @click="prev()">
         <div i-ph-caret-left-light text-3xl text-white />
       </button>
     </div>
-    <div absolute right-0 top="1/2">
+    <div absolute right-0 top="calc(1/2-58px)">
       <button py10 px4 bg-black:30 op10 hover:op100 @click="next()">
         <div i-ph-caret-right-light text-3xl text-white />
       </button>


### PR DESCRIPTION
This is the left navigation button properly centred
<img width="1152" alt="Screenshot 2024-04-05 at 23 37 54" src="https://github.com/nuxt/movies/assets/11798239/4e7f153a-9e43-4e5d-8c29-b046353d8b1f">

This is the right navigation button with the offset
<img width="1152" alt="Screenshot 2024-04-05 at 23 38 00" src="https://github.com/nuxt/movies/assets/11798239/3d112926-8c23-45dd-a236-1e32aec8ddbc">
