### PR TITLE
fix: do not render `dot` separator when infos are missing

### DIFF
--- a/components/media/Hero.vue
+++ b/components/media/Hero.vue
@@ -56,11 +56,11 @@ const mounted = useMounted()
             <div class="op50 hidden md:block">
               {{ $t('{numberOfReviews} Reviews', { numberOfReviews: formatVote(props.item.vote_count) }) }}
             </div>
-            <span op50>·</span>
+            <span v-if="props.item.release_date" op50>·</span>
             <div v-if="props.item.release_date" op50>
               {{ props.item.release_date.slice(0, 4) }}
             </div>
-            <span op50>·</span>
+            <span v-if="props.item.runtime" op50>·</span>
             <div v-if="props.item.runtime" op50>
               {{ formatTime(props.item.runtime) }}
             </div>


### PR DESCRIPTION
<img width="1152" alt="Screenshot 2024-04-06 at 13 42 15" src="https://github.com/nuxt/movies/assets/11798239/c5393dee-6bdd-48c9-b8f7-f833aecd6483">