### PR TITLE
Complete missing translations for existing languages

### DIFF
--- a/internationalization/de-DE.json
+++ b/internationalization/de-DE.json
@@ -53,5 +53,13 @@
   "as {character}": "Rolle: {character}",
 
   "{count} items": "{count} Ergebnisse ",
-  "Search result for: {currentSearch}": "Suchergebnis für {currentSearch}"
+  "Search result for: {currentSearch}": "Suchergebnis für {currentSearch}",
+
+  "Error occurred on fetching": "Fehler beim Abrufen aufgetreten",
+  "Retry": "Erneut versuchen",
+
+  "Home": "Startseite",
+  "Movies": "Filme",
+  "TV Shows": "Fernsehserien",
+  "Search": "Suche"
 }

--- a/internationalization/es-ES.json
+++ b/internationalization/es-ES.json
@@ -3,7 +3,63 @@
   "Top Rated Movies": "Películas mejor valoradas",
   "Upcoming Movies": "Próximas películas",
   "Now Playing Movies": "Películas en cartelera",
-  "Popular TV Shows": "Programas de televisión populares",
-  "Top Rated TV Shows": "Programas de televisión mejor valorados",
-  "TV Shows Airing Today": "Programas de televisión que se emiten hoy"
+  "Popular TV Shows": "Programas de TV populares",
+  "Top Rated TV Shows": "Programas de TV mejor valorados",
+  "TV Shows Airing Today": "Programas de TV que se emiten hoy",
+
+  "Watch Trailer": "Ver tráiler",
+  "Explore more": "Explorar más",
+
+  "Overview": "Visión general",
+  "Videos": "Videos",
+  "Media Photos": "Fotos",
+
+  "Cast": "Reparto",
+  "More like this": "Más como esto",
+
+  "Storyline": "Trama",
+  "Release Date": "Fecha de estreno",
+  "Runtime": "Duración",
+  "Director": "Director",
+  "Budget": "Presupuesto",
+  "Revenue": "Ingresos",
+  "Genre": "Género",
+  "Status": "Estado",
+  "Language": "Idioma",
+  "Production": "Producción",
+
+  "Backdrops": "Fondos",
+  "Posters": "Pósters",
+
+  "Known For": "Conocido por",
+  "Credits": "Créditos",
+  "Person Photos": "Fotos",
+  "(no biography)": "(sin biografía)",
+  "Known for": "Conocido por",
+  "Place of birth": "Lugar de nacimiento",
+  "Birthday": "Cumpleaños",
+
+  "Acting Credits": "Actuación",
+  "Production Credits": "Producción",
+
+  "Type to search...": "Escribe para buscar...",
+  "Type something to search...": "Escribe algo para buscar...",
+
+  "{numberOfReviews} Reviews": "{numberOfReviews} reseñas",
+
+  "{numberOfImages} Images": "{numberOfImages} imágenes",
+  "{numberOfVideos} Videos": "{numberOfVideos} videos",
+
+  "as {character}": "como {character}",
+
+  "{count} items": "{count} artículos",
+  "Search result for: {currentSearch}": "Resultado de búsqueda para: {currentSearch}",
+
+  "Error occurred on fetching": "Error al obtener datos",
+  "Retry": "Reintentar",
+
+  "Home": "Inicio",
+  "Movies": "Películas",
+  "TV Shows": "Series de TV",
+  "Search": "Buscar"
 }

--- a/internationalization/fr-FR.json
+++ b/internationalization/fr-FR.json
@@ -35,6 +35,7 @@
   "Credits": "Filmographie",
   "Person Photos": "Photos",
   "(no biography)": "(pas de biographie)",
+  "Known for": "Connu pour",
   "Place of birth": "Lieu de naissance",
   "Birthday": "Anniversaire",
 

--- a/internationalization/ja.json
+++ b/internationalization/ja.json
@@ -53,5 +53,13 @@
   "as {character}": "演 {character}",
 
   "{count} items": "{count}件",
-  "Search result for: {currentSearch}": "「{currentSearch}」の検索結果 "
+  "Search result for: {currentSearch}": "「{currentSearch}」の検索結果 ",
+
+  "Error occurred on fetching": "取得中にエラーが発生しました",
+  "Retry": "再試行",
+
+  "Home": "ホーム",
+  "Movies": "映画",
+  "TV Shows": "テレビ番組",
+  "Search": "検索"
 }

--- a/internationalization/pt-BR.json
+++ b/internationalization/pt-BR.json
@@ -56,5 +56,10 @@
   "Search result for: {currentSearch}": "Resultados da procura por: {currentSearch}",
 
   "Error occurred on fetching": "Ocorreu um erro na busca",
-  "Retry": "Tentar novamente"
+  "Retry": "Tentar novamente",
+
+  "Home": "Início",
+  "Movies": "Filmes",
+  "TV Shows": "Programas de TV",
+  "Search": "Pesquisar"
 }

--- a/internationalization/pt-PT.json
+++ b/internationalization/pt-PT.json
@@ -56,5 +56,10 @@
   "Search result for: {currentSearch}": "Resultados da pesquisa: {currentSearch}",
 
   "Error occurred on fetching": "Ocorreu um erro na pesquisa",
-  "Retry": "Tentar novamente"
+  "Retry": "Tentar novamente",
+
+  "Home": "Início",
+  "Movies": "Filmes",
+  "TV Shows": "Programas de TV",
+  "Search": "Pesquisar"
 }

--- a/internationalization/zh-CN.json
+++ b/internationalization/zh-CN.json
@@ -53,5 +53,13 @@
   "as {character}": "饰 {character}",
 
   "{count} items": "{count}条结果",
-  "Search result for: {currentSearch}": "搜索 {currentSearch}"
+  "Search result for: {currentSearch}": "搜索 {currentSearch}",
+
+  "Error occurred on fetching": "获取数据时出错",
+  "Retry": "重试",
+
+  "Home": "首页",
+  "Movies": "电影",
+  "TV Shows": "电视剧",
+  "Search": "搜索"
 }


### PR DESCRIPTION
Added missing translations for the languages present in the internationalization folder. Spanish (es-ES), being the language with the most missing phrases, was checked manually by me (thankfully I know it to some extent). For the other languages, the minor additions were made using a language model. Although the additions are minor, a review by someone knowing these languages would be appreciated.