### PR TITLE
fix(i18n): set `fallbackLocale` for missing translations

### DIFF
--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -1,0 +1,5 @@
+export default defineI18nConfig(() => {
+  return {
+    fallbackLocale: 'en',
+  }
+})


### PR DESCRIPTION
### 🔗 Linked issue
* https://github.com/nuxt-modules/i18n/issues/3012
* Resolves #66
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This should resolve #66, but this PR assumes you want to use English as the fallbackLocale, which means any missing translations in the selected language will render the English translations instead if present.

Configuring the i18n module is a bit confusing, options that are specific to Vue I18n (that do not overlap with Nuxt I18n options) need to be set in a `i18n.config.ts` file as it also accept non serializable values. This is something we want to change in the next major.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
