### PR TITLE
fix: duplicated view-transition key on media card

### DIFF
--- a/components/carousel/AutoQuery.vue
+++ b/components/carousel/AutoQuery.vue
@@ -22,6 +22,7 @@ const item = await listMedia(props.query.type, props.query.query, 1)
       v-for="i of item?.results || []"
       :key="i.id"
       :item="i"
+      :query="props.query"
       :type="props.query.type"
       flex-1 w-40 md:w-60
     />

--- a/components/media/Card.vue
+++ b/components/media/Card.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import type { Media, MediaType } from '~/types'
+import type { Media, MediaType, QueryItem } from '~/types'
 
 defineProps<{
   type: MediaType
-  item: Media
+  item: Media,
+  query?: QueryItem
 }>()
 </script>
 
@@ -25,7 +26,7 @@ defineProps<{
         :src="`/tmdb${item.poster_path}`"
         :alt="item.title || item.name"
         w-full h-full object-cover
-        :style="{ 'view-transition-name': `item-${item.id}` }"
+        :style="{ 'view-transition-name': `item-${item.id}${query?.query ? `-${query.query}` : ''}` }"
       />
       <div v-else h-full op10 flex>
         <div i-ph:question ma text-4xl />


### PR DESCRIPTION
### 🔗 Linked issue

resolves #76
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This changes set a unique `view-transition-name`, when a media card component showed several times in same page. Eg. page has more carousels.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
