### PR TITLE
Enhancement & debug

### DIFF
--- a/components/IframeModal.vue
+++ b/components/IframeModal.vue
@@ -2,9 +2,14 @@
 import { onKeyDown } from '@vueuse/core'
 
 const src = ref<string | null>(null)
+const loading = ref(true)
 
 function showModal(link: string) {
   src.value = link
+  loading.value = true
+  setTimeout(() => {
+    loading.value = false
+  }, 7000)
 }
 const el = ref<HTMLIFrameElement>()
 
@@ -34,6 +39,8 @@ onClickOutside(el, () => {
       allow="autoplay; encrypted-media"
       allowfullscreen
       :src="src" w-full m5 lg:m20 border-none
+      @load="loading = false"
     />
+    <Loading v-if="loading" />
   </div>
 </template>

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="fixed inset-0 z-[1000] flex items-center justify-center">
+    <div class="z-0 fixed inset-0 bg-blur bg-[rgba(#8a2a0a,0.25)]" />
+    <div class="z-1 bg-black px-6 py-2 rounded-lg">
+      <img class="w-12 loader" src="/movies.webp" width="25" height="25" alt="Logo">
+    </div>
+  </div>
+</template>
+
+<style>
+.bg-blur {
+  backdrop-filter: saturate(180%) blur(20px);
+}
+
+.loader {
+  aspect-ratio: 1;
+  animation:
+    l3-1 2s infinite linear,
+    l3-2 3s infinite steps(1) -0.5s;
+}
+@keyframes l3-1 {
+  0% {
+    transform: perspective(150px) rotateX(0deg) rotateY(0deg);
+  }
+  50% {
+    transform: perspective(150px) rotateX(180deg) rotateY(0deg);
+  }
+  100% {
+    transform: perspective(150px) rotateX(180deg) rotateY(180deg);
+  }
+}
+</style>

--- a/components/media/Hero.vue
+++ b/components/media/Hero.vue
@@ -44,7 +44,7 @@ const mounted = useMounted()
     >
       <Transition appear name="hero">
         <div v-show="mounted">
-          <h1 mt-2 text-4xl lg:text-5xl line-clamp-2>
+          <h1 mt-2 text-4xl lg:text-5xl line-clamp-2 overflow-visible>
             {{ props.item.title || props.item.name }}
           </h1>
           <div flex="~ row wrap" gap2 items-center mt4>

--- a/pages/[type]/[id].vue
+++ b/pages/[type]/[id].vue
@@ -8,6 +8,7 @@ definePageMeta({
   },
 })
 
+const loadingIndicator = useLoadingIndicator()
 const route = useRoute()
 const type = computed(() => route.params.type as MediaType || 'movie')
 const id = computed(() => route.params.id as string)
@@ -29,6 +30,7 @@ useHead({
 
 <template>
   <div>
+    <Loading v-if="loadingIndicator.isLoading.value" />
     <MediaHero :item="item" />
     <MediaDetails :item="item" :type="type" />
     <CarouselBase v-if="recommendations?.results?.length">


### PR DESCRIPTION
### Enhancement & debug

- [x] 🐞 Media Hero title text cut fixed
- [x] 🐞 Catch Error on show trailer
- [x] 👌 Show a loading in Media Info
- [x] 👌 Show a loading in trailer load

### Description 
Bug fixed when Media hero h1 text overflow-y would be cut  (character like g).
Show loading in trailer load and media info load (detail screen)
