### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false
-shell-emulator=true

--- a/composables/utils.nuxt.test.ts
+++ b/composables/utils.nuxt.test.ts
@@ -102,8 +102,8 @@ describe('utils', () => {
 
   describe('formatVote', () => {
     it('should format vote count correctly', () => {
-      expect(formatVote(1234)).toBe('1.2K')
-      expect(formatVote(56789)).toBe('56.8K')
+      expect(formatVote(1234)).toBe('1.2k')
+      expect(formatVote(56789)).toBe('56.8k')
       expect(formatVote(7.3)).toBe('7.3')
       expect(formatVote(0)).toBe('0')
       expect(formatVote(undefined)).toBe('0')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "build": "nuxt build",
     "dev:proxy": "cd proxy && pnpm dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,13 @@
 packages:
   - proxy
+
+shamefullyHoist: true
+
+strictPeerDependencies: false
+
+shellEmulator: true
+
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  sharp: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`